### PR TITLE
Add backend server and integrate with frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Evaluation App
+
+This project provides a simple front-end and a minimal Node.js backend to store evaluation data.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the server:
+   ```bash
+   npm start
+   ```
+
+The application will be available at `http://localhost:3000`.
+
+## API
+
+- `GET /api/evaluations` - retrieve saved evaluation data.
+- `POST /api/evaluations` - save evaluation data. Send a JSON object matching the structure used by the front-end.
+
+## Notes
+
+Evaluation results are persisted in `data.json` located at the project root.

--- a/index.html
+++ b/index.html
@@ -326,6 +326,19 @@
                     groupScores[groupId] = data[groupId];
                 });
             }
+
+            fetch('/api/evaluations')
+                .then(res => res.json())
+                .then(data => {
+                    Object.keys(data).forEach(groupId => {
+                        groupScores[groupId] = data[groupId];
+                    });
+                    for (let i = 1; i <= 11; i++) {
+                        fillSavedValues(`groupe${i}`);
+                    }
+                    updateClassement();
+                })
+                .catch(err => console.error('Failed to load server data', err));
         }
 
         function fillSavedValues(groupId) {
@@ -489,6 +502,12 @@
             groupScores[groupId][atelierIndex] = { etat, time, esprit };
             localStorage.setItem('evaluationData', JSON.stringify(groupScores));
 
+            fetch('/api/evaluations', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(groupScores)
+            }).catch(err => console.error('Failed to save server data', err));
+
             // Mettre à jour le classement global à chaque modification
             updateClassement();
         }
@@ -637,7 +656,11 @@
             const password = prompt('Entrez le mot de passe pour réinitialiser :');
             if (password === 'btp2024') {
                 localStorage.removeItem('evaluationData');
-                location.reload();
+                fetch('/api/evaluations', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({})
+                }).finally(() => location.reload());
             } else if (password !== null) {
                 alert('Mot de passe incorrect.');
             }
@@ -645,14 +668,12 @@
 
         // Initialisation
         document.addEventListener('DOMContentLoaded', function() {
-            loadSavedData();
             for (let i = 1; i <= 11; i++) {
                 const groupId = `groupe${i}`;
                 const evaluationDiv = document.getElementById(`evaluation-${groupId}`);
                 evaluationDiv.innerHTML = createEvaluationTable(groupId);
-                fillSavedValues(groupId);
             }
+            loadSavedData();
             updateClassement();
         });
-    </script>
-</body></html>
+    </script></body></html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "evaluation-app",
+  "version": "1.0.0",
+  "description": "Evaluation app backend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const cors = require('cors');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DATA_FILE = path.join(__dirname, 'data.json');
+
+app.use(cors());
+app.use(express.json());
+app.use(express.static(__dirname));
+
+function loadData() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+app.get('/api/evaluations', (req, res) => {
+  res.json(loadData());
+});
+
+app.post('/api/evaluations', (req, res) => {
+  saveData(req.body);
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create Node.js Express backend to store evaluation data
- connect front-end to API for saving/loading
- add basic project docs and config

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ed737f8fc83269293c35d92f3dd51